### PR TITLE
Update to a more recent highlight.php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.0.2",
     "require": {
         "php": ">= 5.6",
-        "scrivo/highlight.php": "v9.12.0.4"
+        "scrivo/highlight.php": "v9.15.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
Mainly driven by failing PHP 7.3 tests, probably coming from the older highlight.php version.